### PR TITLE
feat: scaffold Astro/Starlight docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ replay_pid*
 /.idea/
 /target/
 **/target/**
+# Node.js
+node_modules/
+dist/

--- a/documentation/astro/README.md
+++ b/documentation/astro/README.md
@@ -1,0 +1,10 @@
+# Mojave Documentation
+
+This directory contains the documentation site for the Mojave project built with [Astro](https://astro.build/) and [Starlight](https://starlight.astro.build/).
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/documentation/astro/astro.config.mjs
+++ b/documentation/astro/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  integrations: [starlight()],
+});

--- a/documentation/astro/package.json
+++ b/documentation/astro/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mojave-docs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/starlight": "^1.0.0",
+    "astro": "^4.0.0"
+  }
+}

--- a/documentation/astro/public/favicon.svg
+++ b/documentation/astro/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">✨</text></svg>

--- a/documentation/astro/src/content/config.ts
+++ b/documentation/astro/src/content/config.ts
@@ -1,0 +1,10 @@
+import { defineCollection, z } from 'astro:content';
+
+const docs = defineCollection({
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+  }),
+});
+
+export const collections = { docs };

--- a/documentation/astro/src/content/docs/index.mdx
+++ b/documentation/astro/src/content/docs/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Introduction
+---
+
+# Welcome to Mojave Docs
+
+Built with [Astro](https://astro.build/) and [Starlight](https://starlight.astro.build/).

--- a/documentation/astro/src/env.d.ts
+++ b/documentation/astro/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />

--- a/documentation/astro/tsconfig.json
+++ b/documentation/astro/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary
- scaffold new Astro + Starlight documentation site under `documentation/astro`
- include sample intro page and config
- ignore Node.js build output

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@astrojs%2fstarlight)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b709d28832dab11db73c5bc5113